### PR TITLE
Bump sev from `16d039f` to `073b0bd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "sev"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sev#16d039fbd86145ff2e47ea50f9e14d33d21a9264"
+source = "git+https://github.com/enarx/sev#073b0bd50f2e454807e66cad739b5f8c5450a517"
 dependencies = [
  "bitfield",
  "bitflags",

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ fn chain() -> sev::Chain {
         .unwrap_or_exit("unable to export SEV certificates");
 
     let id = firmware()
-        .get_identifer()
+        .get_identifier()
         .unwrap_or_exit("error fetching identifier");
     let url = format!("{}/{}", CEK_SVC, id);
     chain.cek = download(reqwest::blocking::get(&url), Usage::CEK);


### PR DESCRIPTION
This version of 'sev' renamed a public API symbol, so
it's a breaking change that dependabot won't be able
to resolve on its own.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>