### PR TITLE
Depend crates.io 'sev' package, not git revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,8 @@ dependencies = [
 [[package]]
 name = "sev"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sev#3a32c93ee5a6164f6285733e6771b40b38a9422c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e7912c3660e45c8fc84f103ad9c17541c90bfb8dad2e36aeffbe1676bce8f2"
 dependencies = [
  "bitfield",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ is-it-maintained-issue-resolution = { repository = "enarx/sevctl" }
 is-it-maintained-open-issues = { repository = "enarx/sevctl" }
 
 [dependencies]
-sev = { git = "https://github.com/enarx/sev", features = ["openssl"] }
+sev = { version = "0.1", features = ["openssl"] }
 reqwest = { version = "0.10", features= ["blocking"] }
 structopt = "0.3"
 codicon = "3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,7 +421,7 @@ mod verify {
 
     fn ca_chain(filename: PathBuf) -> Result<ca::Chain> {
         let mut file = File::open(&filename).context("unable to open CA certificate chain file")?;
-        Ok(ca::Chain::decode(&mut file, ()).context("unable to decode chain")?)
+        ca::Chain::decode(&mut file, ()).context("unable to decode chain")
     }
 }
 


### PR DESCRIPTION

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
