### PR TITLE
fix: parsing of /sys/module/kvm_amd/parameters/sev

### DIFF
--- a/src/ok.rs
+++ b/src/ok.rs
@@ -469,7 +469,7 @@ fn sev_enabled_in_kvm() -> TestResult {
     let (stat, mesg) = if path.exists() {
         match std::fs::read_to_string(path_loc) {
             Ok(result) => {
-                if result.trim() == "1" {
+                if result.trim() == "1" || result.trim() == "Y" {
                     (TestState::Pass, "enabled".to_string())
                 } else {
                     (


### PR DESCRIPTION
Newer kernels have `Y` instead of `1`.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
