### PR TITLE
sevctl-ok: Allow probing of SNP-related features via CPUID instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ $ sevctl generate ~/my-cert ~/my-key
 
 ### ok
 
-Probes processor, sysfs, and KVM for AMD SEV and SEV-ES related features on the host and emits the results.
+Probes processor, sysfs, and KVM for AMD SEV, SEV-ES, and SEV-SNP related features on the host and emits the results.
 
 ```console
-$ sevctl ok {sev, es}   // Probes support for the generation specified.
-$ sevctl ok             // Probes for both SEV and SEV-ES support.
+$ sevctl ok {sev, es, snp}   // Probes support for the generation specified.
+$ sevctl ok                  // Probes for SEV, SEV-ES, and SEV-SNP support.
 ```
 
 ### provision

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,11 +37,11 @@
 //!
 //! ## ok
 //!
-//! Probes processor, sysfs, and KVM for AMD SEV and SEV-ES related features on the host and emits the results.
+//! Probes processor, sysfs, and KVM for AMD SEV, SEV-ES, and SEV-SNP related features on the host and emits the results.
 //!
 //! ```console
-//! $ sevctl ok {sev, es}   // Probes support for the generation specified.
-//! $ sevctl ok             // Probes for both SEV and SEV-ES support.
+//! $ sevctl ok {sev, es, snp}   // Probes support for the generation specified.
+//! $ sevctl ok                  // Probes for SEV, SEV-ES, and SEV-SNP support.
 //! ```
 //!
 //! ## provision

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -179,6 +179,59 @@ fn collect_tests() -> Vec<Test> {
                             sub: vec![],
                         },
                         Test {
+                            name: "Secure Nested Paging (SEV-SNP)",
+                            gen_mask: SNP_MASK,
+                            run: Box::new(|| {
+                                let res = unsafe { x86_64::__cpuid(0x8000001f) };
+
+                                let stat = if (res.eax & 0x1 << 4) != 0 {
+                                    TestState::Pass
+                                } else {
+                                    TestState::Fail
+                                };
+
+                                TestResult {
+                                    name: "Secure Nested Paging (SEV-SNP)",
+                                    stat,
+                                    mesg: None,
+                                }
+                            }),
+                            sub: vec![Test {
+                                name: "VM Permission Levels",
+                                gen_mask: SNP_MASK,
+                                run: Box::new(|| {
+                                    let res = unsafe { x86_64::__cpuid(0x8000001f) };
+
+                                    let stat = if (res.eax & 0x1 << 5) != 0 {
+                                        TestState::Pass
+                                    } else {
+                                        TestState::Fail
+                                    };
+
+                                    TestResult {
+                                        name: "VM Permission Levels",
+                                        stat,
+                                        mesg: None,
+                                    }
+                                }),
+                                sub: vec![Test {
+                                    name: "Number of VMPLs",
+                                    gen_mask: SNP_MASK,
+                                    run: Box::new(|| {
+                                        let res = unsafe { x86_64::__cpuid(0x8000001f) };
+                                        let num_vmpls = (res.ebx & 0xF000) >> 12;
+
+                                        TestResult {
+                                            name: "Number of VMPLs",
+                                            stat: TestState::Pass,
+                                            mesg: Some(format!("{}", num_vmpls)),
+                                        }
+                                    }),
+                                    sub: vec![],
+                                }],
+                            }],
+                        },
+                        Test {
                             name: "Physical address bit reduction",
                             gen_mask: SEV_MASK,
                             run: Box::new(|| {

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -17,6 +17,9 @@ pub enum SevGeneration {
 
     #[structopt(about = "SEV + Encrypted State")]
     Es,
+
+    #[structopt(about = "SEV + Secure Nested Paging")]
+    Snp,
 }
 
 type TestFn = dyn Fn() -> TestResult;
@@ -24,6 +27,7 @@ type TestFn = dyn Fn() -> TestResult;
 // SEV generation-specific bitmasks.
 const SEV_MASK: usize = 1;
 const ES_MASK: usize = 1 << 1;
+const SNP_MASK: usize = 1 << 2;
 
 struct Test {
     name: &'static str,
@@ -299,10 +303,13 @@ const INDENT: usize = 2;
 pub fn cmd(gen: Option<SevGeneration>, quiet: bool) -> Result<()> {
     let tests = collect_tests();
 
-    let mask = if let Some(SevGeneration::Sev) = gen {
-        SEV_MASK
-    } else {
-        SEV_MASK | ES_MASK
+    let mask = match gen {
+        Some(g) => match g {
+            SevGeneration::Sev => SEV_MASK,
+            SevGeneration::Es => SEV_MASK | ES_MASK,
+            SevGeneration::Snp => SEV_MASK | ES_MASK | SNP_MASK,
+        },
+        None => SEV_MASK | ES_MASK | SNP_MASK,
     };
 
     if run_test(&tests, 0, quiet, mask) {


### PR DESCRIPTION
Tested on both Rome and Milan hardware.
