### PR TITLE
sevctl ok: Fix C-bit location

### DIFF
--- a/src/ok.rs
+++ b/src/ok.rs
@@ -251,7 +251,7 @@ fn collect_tests() -> Vec<Test> {
                             gen_mask: SEV_MASK,
                             run: Box::new(|| {
                                 let res = unsafe { x86_64::__cpuid(0x8000_001f) };
-                                let field = res.ebx & 0b01_1111;
+                                let field = res.ebx & 0b11_1111;
 
                                 TestResult {
                                     name: "C-bit location",


### PR DESCRIPTION
C-bit location is reported in the lower 6 bits of ebx (of cpuid
0x8000_001f), but `sevctl ok` only took the lower 5 bits.  Fix the code to
match the AMD spec.

On an AMD Rome machine, before the change:

    [ PASS ]     - C-bit location: 15

With the fix:

    [ PASS ]     - C-bit location: 47

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>

Closes #84 