### PR TITLE
Make ok subcommand host-architecture specific when not invoked with a specified generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Probes processor, sysfs, and KVM for AMD SEV, SEV-ES, and SEV-SNP related featur
 
 ```console
 $ sevctl ok {sev, es, snp}   // Probes support for the generation specified.
-$ sevctl ok                  // Probes for SEV, SEV-ES, and SEV-SNP support.
+$ sevctl ok                  // Probes support for the host hardware's generation.
 ```
 
 ### provision

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@
 //!
 //! ```console
 //! $ sevctl ok {sev, es, snp}   // Probes support for the generation specified.
-//! $ sevctl ok                  // Probes for SEV, SEV-ES, and SEV-SNP support.
+//! $ sevctl ok                  // Probes support for the host hardware's generation.
 //! ```
 //!
 //! ## provision

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -22,6 +22,16 @@ pub enum SevGeneration {
     Snp,
 }
 
+impl SevGeneration {
+    fn to_mask(&self) -> usize {
+        match self {
+            SevGeneration::Sev => SEV_MASK,
+            SevGeneration::Es => SEV_MASK | ES_MASK,
+            SevGeneration::Snp => SEV_MASK | ES_MASK | SNP_MASK,
+        }
+    }
+}
+
 type TestFn = dyn Fn() -> TestResult;
 
 // SEV generation-specific bitmasks.
@@ -357,12 +367,8 @@ pub fn cmd(gen: Option<SevGeneration>, quiet: bool) -> Result<()> {
     let tests = collect_tests();
 
     let mask = match gen {
-        Some(g) => match g {
-            SevGeneration::Sev => SEV_MASK,
-            SevGeneration::Es => SEV_MASK | ES_MASK,
-            SevGeneration::Snp => SEV_MASK | ES_MASK | SNP_MASK,
-        },
-        None => SEV_MASK | ES_MASK | SNP_MASK,
+        Some(g) => g.to_mask(),
+        None => current_gen().unwrap_or(SevGeneration::Snp).to_mask(),
     };
 
     if run_test(&tests, 0, quiet, mask) {
@@ -580,4 +586,52 @@ fn memlock_rlimit() -> TestResult {
         stat,
         mesg: Some(mesg),
     }
+}
+
+const SEV_CPU_IDS: [&str; 3] = ["7551", "7451", "7401"];
+const ES_CPU_IDS: [&str; 2] = ["7402", "7742"];
+const SNP_CPU_IDS: [&str; 3] = ["7713", "7763", "7413"];
+
+fn current_gen() -> Result<SevGeneration> {
+    let mut bytestr = Vec::with_capacity(48);
+    let cpu_name = {
+        for cpuid in 0x8000_0002_u32..=0x8000_0004_u32 {
+            let cpuid = unsafe { x86_64::__cpuid(cpuid) };
+            let mut bytes: Vec<u8> = [cpuid.eax, cpuid.ebx, cpuid.ecx, cpuid.edx]
+                .iter()
+                .flat_map(|r| r.to_le_bytes().to_vec())
+                .collect();
+            bytestr.append(&mut bytes);
+        }
+
+        String::from_utf8(bytestr)
+            .unwrap_or_else(|_| "ERROR_FOUND".to_string())
+            .trim()
+            .to_string()
+    };
+
+    let name = cpu_name.to_uppercase();
+
+    for id in &SEV_CPU_IDS {
+        if name.contains(id) {
+            return Ok(SevGeneration::Sev);
+        }
+    }
+
+    for id in &ES_CPU_IDS {
+        if name.contains(id) {
+            return Ok(SevGeneration::Es);
+        }
+    }
+
+    for id in &SNP_CPU_IDS {
+        if name.contains(id) {
+            return Ok(SevGeneration::Snp);
+        }
+    }
+
+    Err(error::Context::new(
+        "unable to find AMD processor generation",
+        Box::<Error>::new(ErrorKind::InvalidData.into()),
+    ))
 }


### PR DESCRIPTION
When the ok subcommand is invoked without a generation specified as in:

`sevctl ok`

Instead of testing for SEV, SEV-ES, and SEV-SNP support; check the current processor's generation and test support for that specific generation. For example, if a user is currently on a Rome machine, and `sevctl ok` is invoked, only test support relevant to Rome processors (i.e. do not test for SNP).

Closes #93 
